### PR TITLE
Cleanup some flawed trait definitions

### DIFF
--- a/src/balanced_bagging.jl
+++ b/src/balanced_bagging.jl
@@ -133,7 +133,7 @@ function MLJBase.prefit(composite_model::BalancedBaggingClassifier, verbosity, X
     machines = (machine(:model, Xsub, ysub) for (Xsub, ysub) in X_y_list_s)
     # Average the predictions from nodes
     all_preds = [MLJBase.predict(mach, Xs) for (mach, (X, _)) in zip(machines, X_y_list_s)]
-    yhat = mean(all_preds)
+;    yhat = mean(all_preds)
     return (; predict=yhat, report=(;chosen_T=node(()->T)))
 end
 
@@ -144,17 +144,16 @@ MMI.metadata_pkg(
     package_uuid = "45f359ea-796d-4f51-95a5-deb1a414c586",
     package_url = "https://github.com/JuliaAI/MLJBalancing.jl",
     is_pure_julia = true,
+    is_wrapper = true,
 )
 
 MMI.metadata_model(
     BalancedBaggingClassifier,
-    input_scitype = Union{Union{Infinite,Finite}},
-    output_scitype = Union{Union{Infinite,Finite}},
-    target_scitype = AbstractVector,
+    target_scitype = AbstractVector{<:Finite},
     load_path = "MLJBalancing." * string(BalancedBaggingClassifier),
 )
 
-MMI.iteration_parameter(::Type{<:BalancedBaggingClassifier{P}}) where {P} =
+MMI.iteration_parameter(::Type{<:BalancedBaggingClassifier{<:Any,<:Any,P}}) where P =
     MLJBase.prepend(:model, iteration_parameter(P))
 for trait in [
     :input_scitype,
@@ -173,7 +172,8 @@ for trait in [
     :prediction_type,
 ]
     quote
-        MMI.$trait(::Type{<:BalancedBaggingClassifier{P}}) where {P} = MMI.$trait(P)
+        MMI.$trait(::Type{<:BalancedBaggingClassifier{<:Any,<:Any, P}}) where {P} =
+            MMI.$trait(P)
     end |> eval
 end
 

--- a/src/balanced_bagging.jl
+++ b/src/balanced_bagging.jl
@@ -133,7 +133,7 @@ function MLJBase.prefit(composite_model::BalancedBaggingClassifier, verbosity, X
     machines = (machine(:model, Xsub, ysub) for (Xsub, ysub) in X_y_list_s)
     # Average the predictions from nodes
     all_preds = [MLJBase.predict(mach, Xs) for (mach, (X, _)) in zip(machines, X_y_list_s)]
-;    yhat = mean(all_preds)
+    yhat = mean(all_preds)
     return (; predict=yhat, report=(;chosen_T=node(()->T)))
 end
 

--- a/test/balanced_bagging.jl
+++ b/test/balanced_bagging.jl
@@ -120,6 +120,10 @@ end
     mach = machine(modelo, X, y)
     fit!(mach)
     @test report(mach) == (chosen_T = 9,)
+
+    ## traits
+    @test fit_data_scitype(modelo) == fit_data_scitype(model)
+    @test is_wrapper(modelo) 
 end
 
 

--- a/test/balanced_model.jl
+++ b/test/balanced_model.jl
@@ -52,7 +52,12 @@
 	fit!(mach)
 	y_pred2 = MLJBase.predict(mach, X_test)
 
-	@test y_pred ≈ y_pred2
+        @test y_pred ≈ y_pred2
+
+        # traits:
+        @test fit_data_scitype(balanced_model) ==  fit_data_scitype(model_prob)
+        @test is_wrapper(balanced_model)
+    
 
 	### 2. Make a pipeline of the three balancers and a deterministic model
 	## ordinary way


### PR DESCRIPTION
This fixes flawed traits definitions and changes `is_wrapper` from `false` to `true` in the case of `BalancedBaggingClassifier`. Since the model includes another model as a hyperparameter, this is more technically correct and saves us some headaches in MLJTestIntegration. jl. 

I'd regard these changes as bug fixes - a patch release should suffice (0.1.4).

