### PR TITLE
Setting LTS version as `1.10` using the `lts` tag in the CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
 
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -27,10 +27,10 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
Upgrading the LTS version is something already mentioned in https://github.com/JuliaAI/MLJ.jl/issues/1143.